### PR TITLE
feat: add --spec feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ parameters:
   BURN:
     type: integer
     default: 1
+  # optional spec pattern to pass via "--spec <pattern>"
+  SPEC:
+    type: string
+    default: ''
 
 workflows:
   some-tests:
@@ -91,12 +95,14 @@ workflows:
       or:
         - << pipeline.parameters.GREP >>
         - << pipeline.parameters.GREP_TAGS >>
+        - << pipeline.parameters.SPEC >>
     jobs:
       - cypress/run:
           name: Filtered E2E tests
           no-workspace: true
           group: 'Test grep: << pipeline.parameters.GREP >>'
           tags: << pipeline.parameters.GREP >>
+          spec: << pipeline.parameters.SPEC >>
           env: 'grep="<< pipeline.parameters.GREP >>",grepTags="<< pipeline.parameters.GREP_TAGS >>",grepBurn=<< pipeline.parameters.BURN >>'
 
   all-tests:
@@ -104,6 +110,7 @@ workflows:
       or:
         - << pipeline.parameters.GREP >>
         - << pipeline.parameters.GREP_TAGS >>
+        - << pipeline.parameters.SPEC >>
     jobs:
       # normal build and test workflow
 ```
@@ -140,6 +147,26 @@ You can run all tests tagged `@smoke` using `--tag @smoke` argument
 $ npx run-cy-on-ci --tag @smoke
 # use an alias -t
 $ npx run-cy-on-ci -t @smoke
+```
+
+### Spec
+
+You can pass the `--spec <pattern>` argument to run one or multiple specs (or use its alias `-s`). **Important:** try the pattern in the target project using the `--spec` CLI arguments. It requires `cypress/integration/...` prefix.
+
+```shell
+$ npx run-cy-on-ci --spec cypress/integration/spec1.js
+```
+
+To run all spec files in a folder, use wildcard - make sure to quote it to avoid your shell expanding the wildcards to random filenames.
+
+```shell
+$ npx run-cy-on-ci --spec 'cypress/integration/featureA/**/*.js'
+```
+
+You can also use wildcards in the folders, like this
+
+```shell
+$ npx run-cy-on-ci --spec '**/featureB/**/*.js'
 ```
 
 ### Burn
@@ -211,6 +238,8 @@ This utility uses [debug](https://www.npmjs.com/package/debug) to print verbose 
 ```
 $ DEBUG=run-cy-on-ci ...
 ```
+
+If the launched workflow shows `Build Error` then it might be because the target pipeline does not accept the parameters you are sending to it. Check the target CircleCI config file.
 
 ## Small print
 

--- a/bin/run-cy-on-ci.js
+++ b/bin/run-cy-on-ci.js
@@ -6,6 +6,7 @@ const triggerCircle = require('trigger-circleci-pipeline')
 const arg = require('arg')
 const args = arg({
   '--grep': String,
+  '--spec': String,
   '--tags': String,
   '--burn': Number,
   '--machines': Number,
@@ -14,6 +15,7 @@ const args = arg({
 
   // aliases
   '-g': '--grep',
+  '-s': '--spec',
   '-b': '--burn',
   '-t': '--tags',
   '--tag': '--tags',
@@ -27,10 +29,11 @@ if (!args['--grep'] && args._.length === 1) {
   args['--grep'] = args._[0]
 }
 
-if (!args['--grep'] && !args['--tags']) {
+if (!args['--grep'] && !args['--tags'] && !args['--spec']) {
   console.error('Need part of the title to grep for')
   console.error('--grep <part of title>')
   console.error('or some tags with --tag <tag>')
+  console.error('or spec pattern with --spec <path>')
   process.exit(1)
 }
 
@@ -66,6 +69,9 @@ if (args['--grep']) {
 }
 if (args['--tags']) {
   parameters.GREP_TAGS = args['--tags']
+}
+if (args['--spec']) {
+  parameters.SPEC = args['--spec']
 }
 if (args['--burn']) {
   if (args['--burn'] < 1) {


### PR DESCRIPTION
closes #7 

You can pass the `--spec <pattern>` argument to run one or multiple specs (or use its alias `-s`). **Important:** try the pattern in the target project using the `--spec` CLI arguments. It requires `cypress/integration/...` prefix.

```shell
$ npx run-cy-on-ci --spec cypress/integration/spec1.js
```

To run all spec files in a folder, use wildcard - make sure to quote it to avoid your shell expanding the wildcards to random filenames.

```shell
$ npx run-cy-on-ci --spec 'cypress/integration/featureA/**/*.js'
```

You can also use wildcards in the folders, like this

```shell
$ npx run-cy-on-ci --spec '**/featureB/**/*.js'
```